### PR TITLE
修复使用poedit编辑器打开/zh_Hans/wechatpush.po文件无效的提示：

### DIFF
--- a/po/zh_Hans/wechatpush.po
+++ b/po/zh_Hans/wechatpush.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2025-01-23 13:56+0800\n"
+"PO-Revision-Date: 2025-01-23 14:12+0800\n"
 "Last-Translator: https://github.com/tty228/luci-app-wechatpush\n"
 "Language-Team: \n"
 "Language: zh\n"
@@ -66,7 +66,7 @@ msgstr "推送模式"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:134
 msgid "Do not use push notifications, only use other features."
-msgstr "不使用推送通知，仅使用其他功能"
+msgstr "不使用推送通知，仅使用其他功能。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:135
 msgid "WeChat serverchan"
@@ -97,7 +97,7 @@ msgid ""
 "required. Trusted IP cannot be shared. This channel is no longer recommended."
 msgstr ""
 "使用 企业微信应用消息，配置较为麻烦，且 2022 年 6 月 20 日之后新创建的应用，"
-"需要额外配置可信 IP，可信 IP 不可公用，不再推荐此通道"
+"需要额外配置可信 IP，可信 IP 不可公用，不再推荐此通道。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:139
 msgid "WeChat Work Markdown Version"
@@ -214,7 +214,7 @@ msgid ""
 "trusted IP. This option should be used in conjunction with a proxy server."
 msgstr ""
 "如果是 2022 年 6 月 20 日之后新创建的应用，需设置可信 IP，该选项需配合代理服"
-"务器使用"
+"务器使用。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:192
 msgid "topicIds(Mass sending)"
@@ -226,7 +226,7 @@ msgstr "获取机器人"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:203
 msgid "<br />Send a message to the created bot to initiate a conversation."
-msgstr "<br />与创建的机器人发一条消息，开启对话"
+msgstr "<br />与创建的机器人发一条消息，开启对话。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:208
 msgid "Get chat_id"
@@ -241,7 +241,7 @@ msgid ""
 msgstr ""
 "<br />如需通过群组/频道推送，请创建一个非中文的群组或频道（便于查找 chatid，"
 "后续再更名）<br />将机器人添加至群组，发送信息后通过 https://api.telegram."
-"org/bot token /getUpdates 获取 chatid"
+"org/bot token /getUpdates 获取 chatid。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:226
 msgid ""
@@ -253,7 +253,7 @@ msgid ""
 msgstr ""
 "请参照注释和其他接口文件修改，精力有限，不再支持更多接口，自行调试<br />请参"
 "考类似网站检查 JSON 文件格式：https://www.baidu.com/s?wd=json在线解析<br />文"
-"本框请使用「保存」按钮"
+"本框请使用「保存」按钮。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:229
 msgid "Proxy Address"
@@ -279,14 +279,14 @@ msgstr "发送测试"
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:230
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:67
 msgid "You may need to save the configuration before sending."
-msgstr "你可能需要先保存配置再进行发送"
+msgstr "你可能需要先保存配置再进行发送。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:236
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:578
 msgid ""
 "Message sent successfully. If you don't receive the message, please check "
 "the logs for manual processing."
-msgstr "发送成功，如果收不到信息，请查看日志手动处理"
+msgstr "发送成功，如果收不到信息，请查看日志手动处理。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:238
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:243
@@ -301,7 +301,7 @@ msgstr "发送失败"
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:401
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:583
 msgid "Unknown error: %s."
-msgstr "未知错误：%s"
+msgstr "未知错误：%s。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:248
 msgid "Device Name"
@@ -311,7 +311,7 @@ msgstr "设备名称"
 msgid ""
 "The device name will be displayed in the push message title to identify the "
 "source device of the message."
-msgstr "在推送信息标题中会标识本设备名称，用于区分推送信息的来源设备"
+msgstr "在推送信息标题中会标识本设备名称，用于区分推送信息的来源设备。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:251
 msgid "Check Interval (s)"
@@ -320,7 +320,7 @@ msgstr "检测时间间隔（秒）"
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:255
 msgid ""
 "Shorter intervals provide quicker response but consume more system resources."
-msgstr "越短的时间间隔响应越及时，但会占用更多的系统资源"
+msgstr "越短的时间间隔响应越及时，但会占用更多的系统资源。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:257
 msgid "MAC Device Database"
@@ -353,7 +353,7 @@ msgstr "网络查询"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:265
 msgid "Enables network query, slower response. Only use if space is limited."
-msgstr "网络查询，查询速度较慢且需要梯子，除非空间紧缺，否则请勿使用"
+msgstr "网络查询，查询速度较慢且需要梯子，除非空间紧缺，否则请勿使用。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:267
 msgid "Update MAC Device Database"
@@ -368,7 +368,7 @@ msgid ""
 "Browser timeout or unknown error. If the log shows that the update process "
 "has been established, please ignore this error: %s."
 msgstr ""
-"浏览器超时强制退出或未知错误，若日志显示已建立更新进程，请忽略此错误：%s"
+"浏览器超时强制退出或未知错误，若日志显示已建立更新进程，请忽略此错误：%s。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:285
 msgid "Reset Traffic Data Every Day at Midnight"
@@ -389,7 +389,7 @@ msgid ""
 "「Save」 button in the text box."
 msgstr ""
 "请输入设备 MAC 和设备别名，用空格隔开，例如：<br/> XX:XX:XX:XX:XX:XX 我的手机"
-"<br/> 192.168.1.2 我的电脑<br />文本框请使用「保存」按钮"
+"<br/> 192.168.1.2 我的电脑<br />文本框请使用「保存」按钮。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:306
 msgid "Test IP acquisition command"
@@ -426,7 +426,7 @@ msgid ""
 "Chinese websites. If you need to use this feature, please replace the URLs "
 "with the ones available to you.<br/>Please use the 「Save」 button in the "
 "text box."
-msgstr "从以上列表中随机访问地址<br />文本框请使用「保存」按钮"
+msgstr "从以上列表中随机访问地址<br />文本框请使用「保存」按钮。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:315
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:366
@@ -518,7 +518,7 @@ msgstr "负载报警阈值"
 msgid ""
 "In general, when the load value is lower than the number of logical cores, "
 "you typically don't need to pay much attention to it."
-msgstr "通常情况下，负载值低于逻辑核心数量时，你不需要关注它"
+msgstr "通常情况下，负载值低于逻辑核心数量时，你不需要关注它。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:433
 msgid "Please enter a numeric value only"
@@ -610,7 +610,7 @@ msgid ""
 "misconfigured, change the device IP and clear rules in LUCI."
 msgstr ""
 "ipset 中, \"0\" 为永久拉黑，慎用。如不幸误操作，请更改设备 IP 进入 LUCI 界面"
-"清空规则"
+"清空规则。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:491
 msgid "Port knocking"
@@ -630,7 +630,7 @@ msgstr "登录成功后开放端口<br/>例：\"22\"、\"21:25\"、\"21:25,135:1
 msgid ""
 "If you have disabled LAN port inbound and forwarding in Firewall - Zone "
 "Settings, it won't work."
-msgstr "如在 防火墙 - 区域设置 中禁用了 LAN 口入站和转发，该功能将不起作用"
+msgstr "如在 防火墙 - 区域设置 中禁用了 LAN 口入站和转发，该功能将不起作用。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:505
 msgid ""
@@ -666,7 +666,7 @@ msgid ""
 msgstr ""
 "可在此处添加或删除，后面的数字为剩余时间，添加时只需要输入 IP<br/>由于网页端"
 "的限制，如需清空内容，请保留一处空白的换行，否则内容为空会导致无法提交 "
-"╮(╯_╰)╭<br/>文本框请使用「保存」按钮"
+"╮(╯_╰)╭<br/>文本框请使用「保存」按钮。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:535
 msgid "Scheduled sending"
@@ -832,7 +832,7 @@ msgid ""
 "avoid frequent notifications in dual Wi-Fi scenarios."
 msgstr ""
 "AA:AA:AA:AA:AA:AA\\|BB:BB:BB:BB:BB:BB 可以将多个 MAC 视为同一用户<br/>任一设"
-"备在线后不再推送，设备全部离线时才会推送，避免双 wifi 频繁推送"
+"备在线后不再推送，设备全部离线时才会推送，避免双 wifi 频繁推送。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:649
 msgid "MAC Filtering Mode 2"
@@ -870,7 +870,7 @@ msgstr "当 CPU 温度或负载超过阈值持续超过（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:686
 msgid "If set to 0, it's a single check without considering duration."
-msgstr "如果设置为 0，则为单次检测，不考虑持续时间"
+msgstr "如果设置为 0，则为单次检测，不考虑持续时间。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:688
 msgid "CPU alarm quiet time (seconds)"
@@ -880,7 +880,7 @@ msgstr "CPU 报警免打扰时间（秒）"
 msgid ""
 "No repeat notifications within the set time after the initial push "
 "notification."
-msgstr "首次推送通知后，在设定时间内不再重复提醒"
+msgstr "首次推送通知后，在设定时间内不再重复提醒。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:700
 msgid "Do Not Disturb for Login Reminders"
@@ -894,7 +894,7 @@ msgstr "仅记录到日志"
 msgid ""
 "Ignore all login notifications (including failed logins), and only record "
 "them in the log."
-msgstr "忽略所有登录提醒（包括失败的登录），仅记录到日志"
+msgstr "忽略所有登录提醒（包括失败的登录），仅记录到日志。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:706
 msgid "Send notification only on the first login"
@@ -902,7 +902,7 @@ msgstr "仅在首次登录时推送通知"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:673
 msgid "Send notification only once within the specified time interval."
-msgstr "在设定时间间隔内，仅首次发送推送通知"
+msgstr "在设定时间间隔内，仅首次发送推送通知。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:675
 msgid "Login reminder do not disturb time (s)"
@@ -930,7 +930,7 @@ msgid ""
 "first login IP will be exempt from log recording, preventing log flooding."
 msgstr ""
 "白名单列表内的用户，或者登录 IP 处于首次登录后的免打扰时段，不做日志记录，避"
-"免日志刷屏"
+"免日志刷屏。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:688
 msgid ""
@@ -939,7 +939,7 @@ msgid ""
 "Only record in the log. Mask notation is currently not supported."
 msgstr ""
 "列表内 IP 加入封禁功能白名单(如果可用)，并忽略自动封禁和登录事件推送，仅在日"
-"志中记录，暂不支持掩码位表示"
+"志中记录，暂不支持掩码位表示。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:17
 msgid ""
@@ -987,7 +987,8 @@ msgid ""
 "The IPs in the list are always subjected to online detection regardless of "
 "whether they exist in the ARP list, suitable for secondary routing scenarios."
 msgstr ""
-"列表中的 IP 始终进行在线检测，无论它是否存在于 ARP 列表，适用于二级路由等情况"
+"列表中的 IP 始终进行在线检测，无论它是否存在于 ARP 列表，适用于二级路由等情"
+"况。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:45
 msgid ""
@@ -1001,7 +1002,7 @@ msgid ""
 msgstr ""
 "选中此项后，离线超时时间和离线检测次数只针对需要推送的设备，其余设备使用默认"
 "值，可有效减少检测所需的时间，但会造成在线设备列表中的在线时间不准确，仅建议"
-"设备较多且关注的设备离线频繁时使用"
+"设备较多且关注的设备离线频繁时使用。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:47
 msgid "Disable active detection"
@@ -1014,7 +1015,7 @@ msgid ""
 "are not sensitive to online devices but need other features."
 msgstr ""
 "关闭客户端在线状态的主动探测，因误报较为严重，启用此功能后设备上下线将不再提"
-"示<br/>适用于对在线设备不敏感，但需要其他功能的用户"
+"示<br/>适用于对在线设备不敏感，但需要其他功能的用户。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:52
 msgid "Maximum concurrent processes"
@@ -1024,7 +1025,7 @@ msgstr "最大并发进程数"
 msgid ""
 "Do not change the setting value for low-performance devices, or reduce the "
 "parameters as appropriate."
-msgstr "低性能设备请勿更改设置值，或酌情减少参数"
+msgstr "低性能设备请勿更改设置值，或酌情减少参数。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:120
 msgid "Client list sorting method"
@@ -1034,7 +1035,7 @@ msgstr "客户端列表排序方式"
 msgid ""
 "This will change the sorting method for both the online device list page and "
 "the sorting order in the push content."
-msgstr "这将会同时改变在线设备列表页面和推送内容中的排序方式"
+msgstr "这将会同时改变在线设备列表页面和推送内容中的排序方式。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:58
 msgid "Custom temperature reading command"
@@ -1109,7 +1110,7 @@ msgstr ""
 "\"cat ~/.ssh/OpenWrt_id_rsa.pub >> ~/.ssh/authorized_keys\" # 写入公钥到 "
 "PVE<br/>ssh -i /root/.ssh/id_rsa root@${pve_host} -p ${pve_port} sensors # 因"
 "首次连接时需要确认，为避免脚本错误，请使用私钥连接 PVE 并测试温度命令是否正常"
-"运行。<br/>刷机党自行将 /root/.ssh/ 加入备份列表，避免重复操作"
+"运行。<br/>刷机党自行将 /root/.ssh/ 加入备份列表，避免重复操作。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:76
 msgid "Test temperature command"
@@ -1147,7 +1148,7 @@ msgid ""
 msgstr ""
 "适用于 OpenWrt 作为旁路网关，无法获取设备主机名及完整的局域网设备列表时<br/"
 ">\"从光猫获取主机名列表\"选项仅测试通过 HG5143F/HN8145V 天翼网关，不保证通用"
-"性<br/>\"定期扫描局域网 IP\"选项可能无法获取主机名，请配合设备名备注使用"
+"性<br/>\"定期扫描局域网 IP\"选项可能无法获取主机名，请配合设备名备注使用。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:97
 msgid "Optical modem login URL"
@@ -1211,7 +1212,7 @@ msgstr "抓取信息时间间隔"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:144
 msgid "Generally, frequent capturing is not necessary. Adjust it as needed."
-msgstr "一般不需要频繁抓取，酌情设置"
+msgstr "一般不需要频繁抓取，酌情设置。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:148
 msgid "Unattended tasks"
@@ -1231,7 +1232,8 @@ msgstr "IP 变化后重启 zerotier"
 msgid ""
 "An old issue with zerotier<br/>Cannot reconnect after disconnection, emmm, I "
 "don't know if it has been fixed now."
-msgstr "zerotier 的陈年老问题<br/>断网后不能重新打洞，emmm，我也不知道修了没有"
+msgstr ""
+"zerotier 的陈年老问题<br/>断网后不能重新打洞，emmm，我也不知道修了没有。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:157
 msgid "Redial only during Do-Not-Disturb period"
@@ -1245,7 +1247,7 @@ msgid ""
 "may be unstable."
 msgstr ""
 "避免在白天重拨网络造成 DDNS 域名等待解析，此功能不影响断网检测<br/>因夜间某"
-"些 APP 偷跑流量问题，该功能可能不稳定"
+"些 APP 偷跑流量问题，该功能可能不稳定。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:165
 msgid ""
@@ -1255,7 +1257,7 @@ msgid ""
 "offline."
 msgstr ""
 "只会在列表中设备都不在线时才会执行<br/>免打扰时段一小时后，关注设备五分钟低流"
-"量（约100kb/m）将视为离线"
+"量（约100kb/m）将视为离线。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:169
 msgid "When the network is disconnected"
@@ -1323,4 +1325,4 @@ msgstr "清除日志"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/log.js:124
 msgid "Refresh every 5 seconds."
-msgstr "每 5 秒刷新"
+msgstr "每 5 秒刷新。"

--- a/po/zh_Hans/wechatpush.po
+++ b/po/zh_Hans/wechatpush.po
@@ -1,12 +1,15 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2023-06-01 20:00+0000\n"
-"Last-Translator: https://github.com/tty228/luci-app-wechatpush \n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2025-01-23 13:56+0800\n"
+"Last-Translator: https://github.com/tty228/luci-app-wechatpush\n"
 "Language-Team: \n"
-"Language: zh_Hans\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Weblate 4.18-dev\n"
+"X-Generator: Poedit 3.5\n"
 
 #: applications/luci-app-wechatpush/root/usr/share/luci/menu.d/luci-app-wechatpush.json:3
 msgid "WeChat push"
@@ -29,8 +32,13 @@ msgid "Log"
 msgstr "日志"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:101
-msgid "A tool that can push device messages from OpenWrt to a mobile phone via WeChat or Telegram.<br /><br />If you encounter any issues while using it, please submit them here:"
-msgstr "一个通过微信或 Telegram，从 OpenWrt 上推送设备消息到手机的工具<br /><br />如果你在使用中遇到问题，请到这里提交："
+msgid ""
+"A tool that can push device messages from OpenWrt to a mobile phone via "
+"WeChat or Telegram.<br /><br />If you encounter any issues while using it, "
+"please submit them here:"
+msgstr ""
+"一个通过微信或 Telegram，从 OpenWrt 上推送设备消息到手机的工具<br /><br />如"
+"果你在使用中遇到问题，请到这里提交："
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:101
 msgid "GitHub Project Address"
@@ -65,7 +73,8 @@ msgid "WeChat serverchan"
 msgstr "微信 Server 酱"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:136
-msgid "Using serverchan API, simple configuration, supports multiple push methods"
+msgid ""
+"Using serverchan API, simple configuration, supports multiple push methods"
 msgstr "使用 Server酱 接口，配置较简单，支持多项推送方式"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
@@ -73,7 +82,8 @@ msgid "Serverchan3 APP"
 msgstr "Server 酱 APP"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
-msgid "Using serverchan3 API, simple configuration, support push to ServerChan App"
+msgid ""
+"Using serverchan3 API, simple configuration, support push to ServerChan App"
 msgstr "使用 ServerChan3 接口，配置较简单，支持推送到Server酱 APP"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:137
@@ -81,23 +91,34 @@ msgid "WeChat Work Image Message"
 msgstr "企业微信 图文消息"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:138
-msgid "Using WeChat Work application message, more complex configuration, and starting from June 20, 2022, additional configuration for trusted IP is required. Trusted IP cannot be shared. This channel is no longer recommended."
-msgstr "使用 企业微信应用消息，配置较为麻烦，且 2022 年 6 月 20 日之后新创建的应用，需要额外配置可信 IP，可信 IP 不可公用，不再推荐此通道"
+msgid ""
+"Using WeChat Work application message, more complex configuration, and "
+"starting from June 20, 2022, additional configuration for trusted IP is "
+"required. Trusted IP cannot be shared. This channel is no longer recommended."
+msgstr ""
+"使用 企业微信应用消息，配置较为麻烦，且 2022 年 6 月 20 日之后新创建的应用，"
+"需要额外配置可信 IP，可信 IP 不可公用，不再推荐此通道"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:139
 msgid "WeChat Work Markdown Version"
 msgstr "企业微信 markdown 版"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:140
-msgid "WeChat Work application message in plain text format, no need to click the title to view the content, same as above"
+msgid ""
+"WeChat Work application message in plain text format, no need to click the "
+"title to view the content, same as above"
 msgstr "企业微信应用消息 纯文字版，无需点击标题查看内容，其他同上"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:142
-msgid "Another channel for WeChat push, the configuration is relatively simple, and only supports official accounts"
+msgid ""
+"Another channel for WeChat push, the configuration is relatively simple, and "
+"only supports official accounts"
 msgstr "微信推送的另一个通道，配置较简单，只支持公众号"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:144
-msgid "Another channel for WeChat push, the configuration is relatively simple, and it supports multiple push methods"
+msgid ""
+"Another channel for WeChat push, the configuration is relatively simple, and "
+"it supports multiple push methods"
 msgstr "微信推送的另一个通道，配置较简单，支持多项推送方式"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:146
@@ -179,7 +200,8 @@ msgid "Thumbnail Image File Path"
 msgstr "图片缩略图文件路径"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:181
-msgid "Supports JPG and PNG formats within 2MB <br> Optimal size: 900383 or 2.35:1"
+msgid ""
+"Supports JPG and PNG formats within 2MB <br> Optimal size: 900383 or 2.35:1"
 msgstr "只支持 2MB 以内 JPG、PNG 格式<br>最佳尺寸：900383 或 2.35:1"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:183
@@ -187,8 +209,12 @@ msgid "Trusted IP address"
 msgstr "可信 IP 地址"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:187
-msgid "If the application was created after June 20, 2022, you need to set the trusted IP. This option should be used in conjunction with a proxy server."
-msgstr "如果是 2022 年 6 月 20 日之后新创建的应用，需设置可信 IP，该选项需配合代理服务器使用"
+msgid ""
+"If the application was created after June 20, 2022, you need to set the "
+"trusted IP. This option should be used in conjunction with a proxy server."
+msgstr ""
+"如果是 2022 年 6 月 20 日之后新创建的应用，需设置可信 IP，该选项需配合代理服"
+"务器使用"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:192
 msgid "topicIds(Mass sending)"
@@ -207,20 +233,44 @@ msgid "Get chat_id"
 msgstr "获取 chat_id"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:208
-msgid "<br />If you want to send to a group/channel, please create a non-Chinese group/channel (for easier chatid lookup, you can rename it later).<br />Add the bot to the group, send a message, and use https://api.telegram.org/bot token /getUpdates to obtain the chatid."
-msgstr "<br />如需通过群组/频道推送，请创建一个非中文的群组或频道（便于查找 chatid，后续再更名）<br />将机器人添加至群组，发送信息后通过 https://api.telegram.org/bot token /getUpdates 获取 chatid"
+msgid ""
+"<br />If you want to send to a group/channel, please create a non-Chinese "
+"group/channel (for easier chatid lookup, you can rename it later).<br />Add "
+"the bot to the group, send a message, and use https://api.telegram.org/bot "
+"token /getUpdates to obtain the chatid."
+msgstr ""
+"<br />如需通过群组/频道推送，请创建一个非中文的群组或频道（便于查找 chatid，"
+"后续再更名）<br />将机器人添加至群组，发送信息后通过 https://api.telegram."
+"org/bot token /getUpdates 获取 chatid"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:226
-msgid "Please refer to the comments and other interface files for modifications. Limited resources, no longer supporting more interfaces, please debug on your own.<br />You can use a similar website to check the JSON file format: https://www.google.com/search?q=JSON+Parser+Online<br />Please use the 「Save」 button in the text box."
-msgstr "请参照注释和其他接口文件修改，精力有限，不再支持更多接口，自行调试<br />请参考类似网站检查 JSON 文件格式：https://www.baidu.com/s?wd=json在线解析<br />文本框请使用「保存」按钮"
+msgid ""
+"Please refer to the comments and other interface files for modifications. "
+"Limited resources, no longer supporting more interfaces, please debug on "
+"your own.<br />You can use a similar website to check the JSON file format: "
+"https://www.google.com/search?q=JSON+Parser+Online<br />Please use the "
+"「Save」 button in the text box."
+msgstr ""
+"请参照注释和其他接口文件修改，精力有限，不再支持更多接口，自行调试<br />请参"
+"考类似网站检查 JSON 文件格式：https://www.baidu.com/s?wd=json在线解析<br />文"
+"本框请使用「保存」按钮"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:229
 msgid "Proxy Address"
 msgstr "代理地址"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:230
-msgid "When you want to use a proxy to push information, you can use this option.<br/>This may be helpful for scenarios like trusted IPs for WeChat Work.Using special characters may cause sending failure.<br/>Example:<br/>http://username:password@127.0.0.1:1080<br/>socks5://username:password@127.0.0.1:1080"
-msgstr "当你想要使用代理推送信息时，可以使用这个选项<br/>可能有助于企业微信可信 IP 等情况，默认为空，使用特殊符号可能会造成发送失败<br/>例子：<br/>http://username:password@127.0.0.1:1080<br/>socks5://username:password@127.0.0.1:1080"
+msgid ""
+"When you want to use a proxy to push information, you can use this option."
+"<br/>This may be helpful for scenarios like trusted IPs for WeChat Work."
+"Using special characters may cause sending failure.<br/>Example:<br/>http://"
+"username:password@127.0.0.1:1080<br/>socks5://username:"
+"password@127.0.0.1:1080"
+msgstr ""
+"当你想要使用代理推送信息时，可以使用这个选项<br/>可能有助于企业微信可信 IP 等"
+"情况，默认为空，使用特殊符号可能会造成发送失败<br/>例子：<br/>http://"
+"username:password@127.0.0.1:1080<br/>socks5://username:"
+"password@127.0.0.1:1080"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:230
 msgid "Send Test"
@@ -233,7 +283,9 @@ msgstr "你可能需要先保存配置再进行发送"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:236
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:578
-msgid "Message sent successfully. If you don't receive the message, please check the logs for manual processing."
+msgid ""
+"Message sent successfully. If you don't receive the message, please check "
+"the logs for manual processing."
 msgstr "发送成功，如果收不到信息，请查看日志手动处理"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:238
@@ -256,7 +308,9 @@ msgid "Device Name"
 msgstr "设备名称"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:249
-msgid "The device name will be displayed in the push message title to identify the source device of the message."
+msgid ""
+"The device name will be displayed in the push message title to identify the "
+"source device of the message."
 msgstr "在推送信息标题中会标识本设备名称，用于区分推送信息的来源设备"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:251
@@ -264,7 +318,8 @@ msgid "Check Interval (s)"
 msgstr "检测时间间隔（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:255
-msgid "Shorter intervals provide quicker response but consume more system resources."
+msgid ""
+"Shorter intervals provide quicker response but consume more system resources."
 msgstr "越短的时间间隔响应越及时，但会占用更多的系统资源"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:257
@@ -280,7 +335,8 @@ msgid "Simplified Version"
 msgstr "简化版"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:261
-msgid "Includes common device manufacturers, occupies approximately 200Kb of space"
+msgid ""
+"Includes common device manufacturers, occupies approximately 200Kb of space"
 msgstr "仅包含常见设备厂商，约占用 200Kb 空间"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:262
@@ -308,8 +364,11 @@ msgid "Database is up to date, skipping update"
 msgstr "已是最新，跳过更新"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:278
-msgid "Browser timeout or unknown error. If the log shows that the update process has been established, please ignore this error: %s."
-msgstr "浏览器超时强制退出或未知错误，若日志显示已建立更新进程，请忽略此错误：%s"
+msgid ""
+"Browser timeout or unknown error. If the log shows that the update process "
+"has been established, please ignore this error: %s."
+msgstr ""
+"浏览器超时强制退出或未知错误，若日志显示已建立更新进程，请忽略此错误：%s"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:285
 msgid "Reset Traffic Data Every Day at Midnight"
@@ -324,8 +383,13 @@ msgid "Device Alias"
 msgstr "设备别名"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:303
-msgid "Please enter the device MAC and device alias separated by a space, such as:<br/> XX:XX:XX:XX:XX:XX My Phone<br/> 192.168.1.2 My PC<br />Please use the 「Save」 button in the text box."
-msgstr "请输入设备 MAC 和设备别名，用空格隔开，例如：<br/> XX:XX:XX:XX:XX:XX 我的手机<br/> 192.168.1.2 我的电脑<br />文本框请使用「保存」按钮"
+msgid ""
+"Please enter the device MAC and device alias separated by a space, such as:"
+"<br/> XX:XX:XX:XX:XX:XX My Phone<br/> 192.168.1.2 My PC<br />Please use the "
+"「Save」 button in the text box."
+msgstr ""
+"请输入设备 MAC 和设备别名，用空格隔开，例如：<br/> XX:XX:XX:XX:XX:XX 我的手机"
+"<br/> 192.168.1.2 我的电脑<br />文本框请使用「保存」按钮"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:306
 msgid "Test IP acquisition command"
@@ -347,17 +411,28 @@ msgstr "通过 URL 获取"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:312
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:363
-msgid "May fail due to server stability and frequent connections.<br/>If the interface can obtain the IP address properly, it is not recommended to use this method."
-msgstr "会因服务器稳定性、连接频繁等原因导致获取失败。<br/>如接口可以正常获取 IP，不推荐使用此方法。"
+msgid ""
+"May fail due to server stability and frequent connections.<br/>If the "
+"interface can obtain the IP address properly, it is not recommended to use "
+"this method."
+msgstr ""
+"会因服务器稳定性、连接频繁等原因导致获取失败。<br/>如接口可以正常获取 IP，不"
+"推荐使用此方法。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:337
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:388
-msgid "Access a random address from the list above,URLs in the list are specific to Chinese websites. If you need to use this feature, please replace the URLs with the ones available to you.<br/>Please use the 「Save」 button in the text box."
+msgid ""
+"Access a random address from the list above,URLs in the list are specific to "
+"Chinese websites. If you need to use this feature, please replace the URLs "
+"with the ones available to you.<br/>Please use the 「Save」 button in the "
+"text box."
 msgstr "从以上列表中随机访问地址<br />文本框请使用「保存」按钮"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:315
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:366
-msgid "Generally, it should be the pppoe-wan or WAN interface. For multi-dial environments, please select the appropriate interface yourself."
+msgid ""
+"Generally, it should be the pppoe-wan or WAN interface. For multi-dial "
+"environments, please select the appropriate interface yourself."
 msgstr "一般应为 pppoe-wan 或 WAN 接口。多拨环境请自行选择。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:321
@@ -397,8 +472,12 @@ msgid "Automatically update API list"
 msgstr "API 列表自动更新"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:409
-msgid "When multiple IP retrieval attempts fail, try to automatically update the list file from GitHub"
-msgstr "当多次获取 IP 失败时，尝试自动从 GitHub 上更新列表文件<br/>因为懒得做外链，所以请确保你可以链接 raw.githubusercontent.com"
+msgid ""
+"When multiple IP retrieval attempts fail, try to automatically update the "
+"list file from GitHub"
+msgstr ""
+"当多次获取 IP 失败时，尝试自动从 GitHub 上更新列表文件<br/>因为懒得做外链，所"
+"以请确保你可以链接 raw.githubusercontent.com"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:413
 msgid "Device Online/Offline Notification"
@@ -425,15 +504,20 @@ msgid "Temperature Alert"
 msgstr "温度报警"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:422
-msgid "Device alert will be triggered only if it exceeds the set value continuously for five minutes, and there won't be a second reminder within an hour."
-msgstr "设备报警只会在连续五分钟超过设定值时才会推送，一个小时内不会再提醒第二次。"
+msgid ""
+"Device alert will be triggered only if it exceeds the set value continuously "
+"for five minutes, and there won't be a second reminder within an hour."
+msgstr ""
+"设备报警只会在连续五分钟超过设定值时才会推送，一个小时内不会再提醒第二次。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:424
 msgid "Load alert threshold"
 msgstr "负载报警阈值"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:451
-msgid "In general, when the load value is lower than the number of logical cores, you typically don't need to pay much attention to it."
+msgid ""
+"In general, when the load value is lower than the number of logical cores, "
+"you typically don't need to pay much attention to it."
 msgstr "通常情况下，负载值低于逻辑核心数量时，你不需要关注它"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:433
@@ -445,7 +529,9 @@ msgid "Temperature alert threshold"
 msgstr "温度报警阈值"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:441
-msgid "Please confirm that the device can retrieve temperature. If you need to modify the command, please go to advanced settings."
+msgid ""
+"Please confirm that the device can retrieve temperature. If you need to "
+"modify the command, please go to advanced settings."
 msgstr "请确认设备可以获取温度。如果需修改命令，请移步高级设置。"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:443
@@ -481,7 +567,9 @@ msgid "Device abnormal traffic alert"
 msgstr "设备异常流量警报"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:459
-msgid "Please ensure that you can retrieve device traffic information correctly, otherwise this feature will not work properly"
+msgid ""
+"Please ensure that you can retrieve device traffic information correctly, "
+"otherwise this feature will not work properly"
 msgstr "请确保可以正确获取设备流量情况，否则此功能无法正常工作"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:462
@@ -517,8 +605,12 @@ msgid "Blacklisting time (s)"
 msgstr "拉黑时间（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:489
-msgid "\"0\" in ipset means permanent blacklist, use with caution. If misconfigured, change the device IP and clear rules in LUCI."
-msgstr "ipset 中, \"0\" 为永久拉黑，慎用。如不幸误操作，请更改设备 IP 进入 LUCI 界面清空规则"
+msgid ""
+"\"0\" in ipset means permanent blacklist, use with caution. If "
+"misconfigured, change the device IP and clear rules in LUCI."
+msgstr ""
+"ipset 中, \"0\" 为永久拉黑，慎用。如不幸误操作，请更改设备 IP 进入 LUCI 界面"
+"清空规则"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:491
 msgid "Port knocking"
@@ -529,16 +621,28 @@ msgid "Port"
 msgstr "端口"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:499
-msgid "Open port after successful login<br/>example：\"22\"、\"21:25\"、\"21:25,135:139\""
+msgid ""
+"Open port after successful login<br/>example："
+"\"22\"、\"21:25\"、\"21:25,135:139\""
 msgstr "登录成功后开放端口<br/>例：\"22\"、\"21:25\"、\"21:25,135:139\""
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:494
-msgid "If you have disabled LAN port inbound and forwarding in Firewall - Zone Settings, it won't work."
+msgid ""
+"If you have disabled LAN port inbound and forwarding in Firewall - Zone "
+"Settings, it won't work."
 msgstr "如在 防火墙 - 区域设置 中禁用了 LAN 口入站和转发，该功能将不起作用"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:505
-msgid "Example: Forward port 13389 of this device (IPv4:10.0.0.1 / IPv6:fe80::10:0:0:2) to port 3389 of (IPv4:10.0.0.2 / IPv6:fe80::10:0:0:8)<br/>\"10.0.0.1,13389,10.0.0.2,3389\"<br/>\"fe80::10:0:0:1,13389,fe80::10:0:0:2,3389\""
-msgstr "例：将本机 (IPv4:10.0.0.1 / IPv6:fe80::10:0:0:2) 的 13389 端口转发到 (IPv4:10.0.0.2 / IPv6:fe80::10:0:0:8) 的 3389 端口:<br/>\"10.0.0.1,13389,10.0.0.2,3389\"<br/>\"fe80::10:0:0:2,13389,fe80::10:0:0:8,3389\""
+msgid ""
+"Example: Forward port 13389 of this device (IPv4:10.0.0.1 / IPv6:"
+"fe80::10:0:0:2) to port 3389 of (IPv4:10.0.0.2 / IPv6:fe80::10:0:0:8)<br/"
+">\"10.0.0.1,13389,10.0.0.2,3389\"<br/>\"fe80::10:0:0:1,13389,"
+"fe80::10:0:0:2,3389\""
+msgstr ""
+"例：将本机 (IPv4:10.0.0.1 / IPv6:fe80::10:0:0:2) 的 13389 端口转发到 "
+"(IPv4:10.0.0.2 / IPv6:fe80::10:0:0:8) 的 3389 端口:<br/"
+">\"10.0.0.1,13389,10.0.0.2,3389\"<br/>\"fe80::10:0:0:2,13389,"
+"fe80::10:0:0:8,3389\""
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:508
 msgid "Release time (s)"
@@ -553,8 +657,16 @@ msgid "IP blacklist"
 msgstr "IP 黑名单列表"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:529
-msgid "You can add or delete here, the numbers after represent the remaining time. When adding, only the IP needs to be entered.<br/>Due to limitations on the web interface, please keep one empty line if you need to clear the content; otherwise, it will not be possible to submit. ╮(╯_╰)╭<br/>Please use the 「Save」 button in the text box."
-msgstr "可在此处添加或删除，后面的数字为剩余时间，添加时只需要输入 IP<br/>由于网页端的限制，如需清空内容，请保留一处空白的换行，否则内容为空会导致无法提交 ╮(╯_╰)╭<br/>文本框请使用「保存」按钮"
+msgid ""
+"You can add or delete here, the numbers after represent the remaining time. "
+"When adding, only the IP needs to be entered.<br/>Due to limitations on the "
+"web interface, please keep one empty line if you need to clear the content; "
+"otherwise, it will not be possible to submit. ╮(╯_╰)╭<br/>Please use the "
+"「Save」 button in the text box."
+msgstr ""
+"可在此处添加或删除，后面的数字为剩余时间，添加时只需要输入 IP<br/>由于网页端"
+"的限制，如需清空内容，请保留一处空白的换行，否则内容为空会导致无法提交 "
+"╮(╯_╰)╭<br/>文本框请使用「保存」按钮"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:535
 msgid "Scheduled sending"
@@ -623,8 +735,13 @@ msgid "Manual sending"
 msgstr "手动发送"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:572
-msgid "You may need to save the configuration before sending.<br/>Due to browser timeout limitations, if the program is not running, it may exit due to timeout during device list initialization"
-msgstr "你可能需要先保存配置再进行发送<br/>由于浏览器超时限制，若程序未在运行，可能会因初始化设备列表超时退出"
+msgid ""
+"You may need to save the configuration before sending.<br/>Due to browser "
+"timeout limitations, if the program is not running, it may exit due to "
+"timeout during device list initialization"
+msgstr ""
+"你可能需要先保存配置再进行发送<br/>由于浏览器超时限制，若程序未在运行，可能会"
+"因初始化设备列表超时退出"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:591
 msgid "Simplified mode"
@@ -651,7 +768,9 @@ msgid "Mode 1: Script Suspension"
 msgstr "模式一：脚本挂起"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:600
-msgid "Suspend all script actions, including unattended tasks, until the end of the time period"
+msgid ""
+"Suspend all script actions, including unattended tasks, until the end of the "
+"time period"
 msgstr "暂停脚本任何动作，包括无人值守任务，直到时段结束"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:601
@@ -688,6 +807,7 @@ msgid "Notify only devices in the list"
 msgstr "仅通知列表内设备"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:629
+#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:644
 msgid "Notify only devices using this interface"
 msgstr "仅通知此接口设备"
 
@@ -705,12 +825,14 @@ msgid "Followed device list"
 msgstr "关注设备列表"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:641
-msgid "AA:AA:AA:AA:AA:AA\\|BB:BB:BB:BB:BB:BB Multiple MAC addresses can be treated as the same user.<br/>Notifications will not be sent once any device is online, and notifications will only be sent when all devices are offline to avoid frequent notifications in dual Wi-Fi scenarios."
-msgstr "AA:AA:AA:AA:AA:AA\\|BB:BB:BB:BB:BB:BB 可以将多个 MAC 视为同一用户<br/>任一设备在线后不再推送，设备全部离线时才会推送，避免双 wifi 频繁推送"
-
-#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:644
-msgid "Notify only devices using this interface"
-msgstr "仅通知此接口设备"
+msgid ""
+"AA:AA:AA:AA:AA:AA\\|BB:BB:BB:BB:BB:BB Multiple MAC addresses can be treated "
+"as the same user.<br/>Notifications will not be sent once any device is "
+"online, and notifications will only be sent when all devices are offline to "
+"avoid frequent notifications in dual Wi-Fi scenarios."
+msgstr ""
+"AA:AA:AA:AA:AA:AA\\|BB:BB:BB:BB:BB:BB 可以将多个 MAC 视为同一用户<br/>任一设"
+"备在线后不再推送，设备全部离线时才会推送，避免双 wifi 频繁推送"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:649
 msgid "MAC Filtering Mode 2"
@@ -741,7 +863,9 @@ msgid "Do Not Disturb device offline list"
 msgstr "设备离线免打扰列表"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:682
-msgid "When CPU temperature or load exceeds the threshold continuously for (s) seconds."
+msgid ""
+"When CPU temperature or load exceeds the threshold continuously for (s) "
+"seconds."
 msgstr "当 CPU 温度或负载超过阈值持续超过（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:686
@@ -753,7 +877,9 @@ msgid "CPU alarm quiet time (seconds)"
 msgstr "CPU 报警免打扰时间（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:692
-msgid "No repeat notifications within the set time after the initial push notification."
+msgid ""
+"No repeat notifications within the set time after the initial push "
+"notification."
 msgstr "首次推送通知后，在设定时间内不再重复提醒"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:700
@@ -765,7 +891,9 @@ msgid "Only record in the log"
 msgstr "仅记录到日志"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:704
-msgid "Ignore all login notifications (including failed logins), and only record them in the log."
+msgid ""
+"Ignore all login notifications (including failed logins), and only record "
+"them in the log."
 msgstr "忽略所有登录提醒（包括失败的登录），仅记录到日志"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:706
@@ -781,8 +909,12 @@ msgid "Login reminder do not disturb time (s)"
 msgstr "登录提醒免打扰时间（秒）"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:679
-msgid "Send notification after the first login and do not repeat within the specified time<br/>Take a shortcut and read the login time from the log"
-msgstr "首次登录后推送通知，在设定时间内不再重复提醒<br/>偷懒一下，登录时间从日志中读取，请确保开启日志功能"
+msgid ""
+"Send notification after the first login and do not repeat within the "
+"specified time<br/>Take a shortcut and read the login time from the log"
+msgstr ""
+"首次登录后推送通知，在设定时间内不再重复提醒<br/>偷懒一下，登录时间从日志中读"
+"取，请确保开启日志功能"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:682
 msgid "Login reminder whitelist"
@@ -793,15 +925,26 @@ msgid "Login reminder log anti-flooding"
 msgstr "登录提醒日志免刷屏"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:690
-msgid "Users in the whitelist or during the undisturbed time period after their first login IP will be exempt from log recording, preventing log flooding."
-msgstr "白名单列表内的用户，或者登录 IP 处于首次登录后的免打扰时段，不做日志记录，避免日志刷屏"
+msgid ""
+"Users in the whitelist or during the undisturbed time period after their "
+"first login IP will be exempt from log recording, preventing log flooding."
+msgstr ""
+"白名单列表内的用户，或者登录 IP 处于首次登录后的免打扰时段，不做日志记录，避"
+"免日志刷屏"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:688
-msgid "Add the IP addresses in the list to the whitelist for the blocking function (if available), and ignore automatic blocking and login event notifications. Only record in the log. Mask notation is currently not supported."
-msgstr "列表内 IP 加入封禁功能白名单(如果可用)，并忽略自动封禁和登录事件推送，仅在日志中记录，暂不支持掩码位表示"
+msgid ""
+"Add the IP addresses in the list to the whitelist for the blocking function "
+"(if available), and ignore automatic blocking and login event notifications. "
+"Only record in the log. Mask notation is currently not supported."
+msgstr ""
+"列表内 IP 加入封禁功能白名单(如果可用)，并忽略自动封禁和登录事件推送，仅在日"
+"志中记录，暂不支持掩码位表示"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:17
-msgid "If you are not familiar with the meanings of these options, please do not modify them.<br/><br/>"
+msgid ""
+"If you are not familiar with the meanings of these options, please do not "
+"modify them.<br/><br/>"
 msgstr "如果你不了解这些选项的含义，请不要修改这些选项<br/><br/>"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:19
@@ -821,11 +964,18 @@ msgid "Offline detection count"
 msgstr "离线检测次数"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:37
-msgid "If the device has good signal strength and no Wi-Fi sleep issues, you can reduce the above values.<br/>Due to the mysterious nature of Wi-Fi sleep during the night, if you encounter frequent disconnections, please adjust the parameters accordingly.<br/>..╮(╯_╰）╭.."
-msgstr "若设备信号强度良好，无息屏 WiFi 休眠问题，可以减少以上数值<br/>因夜间 WiFi 息屏休眠较为玄学，遇到设备频繁推送断开，烦请自行调整参数<br/>..╮(╯_╰）╭.."
+msgid ""
+"If the device has good signal strength and no Wi-Fi sleep issues, you can "
+"reduce the above values.<br/>Due to the mysterious nature of Wi-Fi sleep "
+"during the night, if you encounter frequent disconnections, please adjust "
+"the parameters accordingly.<br/>..╮(╯_╰）╭.."
+msgstr ""
+"若设备信号强度良好，无息屏 WiFi 休眠问题，可以减少以上数值<br/>因夜间 WiFi 息"
+"屏休眠较为玄学，遇到设备频繁推送断开，烦请自行调整参数<br/>..╮(╯_╰）╭.."
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:42
-msgid "Offline timeout applies only to the devices that receive push notifications"
+msgid ""
+"Offline timeout applies only to the devices that receive push notifications"
 msgstr "离线超时只针对推送设备"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:95
@@ -833,27 +983,47 @@ msgid "IP address to always scan"
 msgstr "始终扫描的 IP"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:95
-msgid "The IPs in the list are always subjected to online detection regardless of whether they exist in the ARP list, suitable for secondary routing scenarios."
-msgstr "列表中的 IP 始终进行在线检测，无论它是否存在于 ARP 列表，适用于二级路由等情况"
+msgid ""
+"The IPs in the list are always subjected to online detection regardless of "
+"whether they exist in the ARP list, suitable for secondary routing scenarios."
+msgstr ""
+"列表中的 IP 始终进行在线检测，无论它是否存在于 ARP 列表，适用于二级路由等情况"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:45
-msgid "When this option is selected, the offline timeout and offline detection count apply only to the devices that require push notifications. Other devices will use default values, which can significantly reduce the time required for detection. However, it may result in inaccurate online time displayed in the online devices list. It is recommended to enable this option only when there are many devices and frequent offline occurrences are observed for specific devices of interest."
-msgstr "选中此项后，离线超时时间和离线检测次数只针对需要推送的设备，其余设备使用默认值，可有效减少检测所需的时间，但会造成在线设备列表中的在线时间不准确，仅建议设备较多且关注的设备离线频繁时使用"
+msgid ""
+"When this option is selected, the offline timeout and offline detection "
+"count apply only to the devices that require push notifications. Other "
+"devices will use default values, which can significantly reduce the time "
+"required for detection. However, it may result in inaccurate online time "
+"displayed in the online devices list. It is recommended to enable this "
+"option only when there are many devices and frequent offline occurrences are "
+"observed for specific devices of interest."
+msgstr ""
+"选中此项后，离线超时时间和离线检测次数只针对需要推送的设备，其余设备使用默认"
+"值，可有效减少检测所需的时间，但会造成在线设备列表中的在线时间不准确，仅建议"
+"设备较多且关注的设备离线频繁时使用"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:47
 msgid "Disable active detection"
 msgstr "关闭主动探测"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:50
-msgid "Disable active detection of client online status. Enabling this feature will no longer prompt device online/offline events.<br/>Suitable for users who are not sensitive to online devices but need other features."
-msgstr "关闭客户端在线状态的主动探测，因误报较为严重，启用此功能后设备上下线将不再提示<br/>适用于对在线设备不敏感，但需要其他功能的用户"
+msgid ""
+"Disable active detection of client online status. Enabling this feature will "
+"no longer prompt device online/offline events.<br/>Suitable for users who "
+"are not sensitive to online devices but need other features."
+msgstr ""
+"关闭客户端在线状态的主动探测，因误报较为严重，启用此功能后设备上下线将不再提"
+"示<br/>适用于对在线设备不敏感，但需要其他功能的用户"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:52
 msgid "Maximum concurrent processes"
 msgstr "最大并发进程数"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:56
-msgid "Do not change the setting value for low-performance devices, or reduce the parameters as appropriate."
+msgid ""
+"Do not change the setting value for low-performance devices, or reduce the "
+"parameters as appropriate."
 msgstr "低性能设备请勿更改设置值，或酌情减少参数"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:120
@@ -861,7 +1031,9 @@ msgid "Client list sorting method"
 msgstr "客户端列表排序方式"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:52
-msgid "This will change the sorting method for both the online device list page and the sorting order in the push content."
+msgid ""
+"This will change the sorting method for both the online device list page and "
+"the sorting order in the push content."
 msgstr "这将会同时改变在线设备列表页面和推送内容中的排序方式"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:58
@@ -877,8 +1049,19 @@ msgid "Proxmox Virtual Environment"
 msgstr "PVE 虚拟机"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:62
-msgid "If you need to use special symbols such as quotes, $, !, etc. in custom commands, you need to escape them yourself.<br/>You can use the command eval echo $(uci get wechatpush.wechatpush.soc_code) to view command output and error information.<br/>The execution result should be a pure number (including decimals) for temperature comparison.<br/>Here is an example that does not require escaping:<br/>cat /sys/class/thermal/thermal_zone0/temp|sort -nr|head -n1|cut -c-2"
-msgstr "自定义命令如需使用特殊符号，如引号、$、!等，则需要自行转义<br/>可以使用 eval echo $(uci get wechatpush.wechatpush.soc_code) 命令查看命令输出及错误信息<br/>执行结果需为纯数字（可带小数），用于温度对比<br/>一个无需转义的例子：<br/>cat /sys/class/thermal/thermal_zone0/temp|sort -nr|head -n1|cut -c-2"
+msgid ""
+"If you need to use special symbols such as quotes, $, !, etc. in custom "
+"commands, you need to escape them yourself.<br/>You can use the command eval "
+"echo $(uci get wechatpush.wechatpush.soc_code) to view command output and "
+"error information.<br/>The execution result should be a pure number "
+"(including decimals) for temperature comparison.<br/>Here is an example that "
+"does not require escaping:<br/>cat /sys/class/thermal/thermal_zone0/temp|"
+"sort -nr|head -n1|cut -c-2"
+msgstr ""
+"自定义命令如需使用特殊符号，如引号、$、!等，则需要自行转义<br/>可以使用 eval "
+"echo $(uci get wechatpush.wechatpush.soc_code) 命令查看命令输出及错误信息<br/"
+">执行结果需为纯数字（可带小数），用于温度对比<br/>一个无需转义的例子：<br/"
+">cat /sys/class/thermal/thermal_zone0/temp|sort -nr|head -n1|cut -c-2"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:64
 msgid "Host machine address"
@@ -889,8 +1072,44 @@ msgid "Host machine SSH port"
 msgstr "宿主机 SSH 端口"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:73
-msgid "The default SSH port is 22. If you have a custom port, please fill in the custom SSH port.<br/>Please make sure you have set up key-based login, otherwise it may cause script errors.<br/>Install the sensors command on PVE by searching on the internet.<br/>Example for key-based login (modify the address and port number accordingly):<br/>opkg update # Update package list<br/>opkg install openssh-client openssh-keygen # Install openssh client<br/>echo -e \"\\n\" | ssh-keygen -t rsa # Generate key file (no passphrase)<br/>pve_host=`uci get wechatpush.config.server_host` || pve_host=\"10.0.0.3\" # Read the PVE host address from the configuration file, If not saved, please fill in by yourself.<br/>pve_port=`uci get wechatpush.config.server_port` || pve_host=\"22\" # Read the PVE host SSH port number from the configuration file, If not saved, please fill in by yourself.<br/>ssh -o StrictHostKeyChecking=yes root@${pve_host} -p ${pve_port} \"tee -a ~/.ssh/OpenWrt_id_rsa.pub\" < ~/.ssh/id_rsa.pub # Transfer public key to PVE<br/>ssh root@${pve_host} -p ${pve_port} \"cat ~/.ssh/OpenWrt_id_rsa.pub >> ~/.ssh/authorized_keys\" # Write public key to PVE<br/>ssh -i /root/.ssh/id_rsa root@${pve_host} -p ${pve_port} sensors # To avoid script errors during the initial connection, please use a private key to connect to PVE and test the temperature command for its proper functioning.<br/>For users who frequently flash firmware, please add /root/.ssh/ to the backup list to avoid duplicate operations."
-msgstr "SSH 端口默认为 22，如有自定义，请填写自定义 SSH 端口<br/>请确认已经设置好密钥登陆，否则会引起脚本无法运行等错误！<br/>PVE 安装 sensors 命令自行百度<br/>密钥登陆例（自行修改地址与端口号）：<br/>opkg update #更新列表<br/>opkg install openssh-client openssh-keygen #安装openssh客户端<br/>echo -e \"\\n\" | ssh-keygen -t rsa # 生成密钥文件（空密码）<br/>pve_host=`uci get wechatpush.config.server_host` || pve_host=\"10.0.0.3\" # 读取配置文件中的 pve 主机地址，如果未保存设置，请自行填写 <br/>pve_port=`uci get wechatpush.config.server_port` || pve_port=\"22\" # 读取配置文件中的 pve 主机 ssh 端口号，如果未保存设置，请自行填写 <br/>ssh -o StrictHostKeyChecking=yes root@${pve_host} -p ${pve_port} \"tee -a ~/.ssh/OpenWrt_id_rsa.pub\" < ~/.ssh/id_rsa.pub # 传送公钥到 PVE<br/>ssh root@${pve_host} -p ${pve_port} \"cat ~/.ssh/OpenWrt_id_rsa.pub >> ~/.ssh/authorized_keys\" # 写入公钥到 PVE<br/>ssh -i /root/.ssh/id_rsa root@${pve_host} -p ${pve_port} sensors # 因首次连接时需要确认，为避免脚本错误，请使用私钥连接 PVE 并测试温度命令是否正常运行。<br/>刷机党自行将 /root/.ssh/ 加入备份列表，避免重复操作"
+msgid ""
+"The default SSH port is 22. If you have a custom port, please fill in the "
+"custom SSH port.<br/>Please make sure you have set up key-based login, "
+"otherwise it may cause script errors.<br/>Install the sensors command on PVE "
+"by searching on the internet.<br/>Example for key-based login (modify the "
+"address and port number accordingly):<br/>opkg update # Update package "
+"list<br/>opkg install openssh-client openssh-keygen # Install openssh "
+"client<br/>echo -e \"\\n\" | ssh-keygen -t rsa # Generate key file (no "
+"passphrase)<br/>pve_host=`uci get wechatpush.config.server_host` || "
+"pve_host=\"10.0.0.3\" # Read the PVE host address from the configuration "
+"file, If not saved, please fill in by yourself.<br/>pve_port=`uci get "
+"wechatpush.config.server_port` || pve_host=\"22\" # Read the PVE host SSH "
+"port number from the configuration file, If not saved, please fill in by "
+"yourself.<br/>ssh -o StrictHostKeyChecking=yes root@${pve_host} -p "
+"${pve_port} \"tee -a ~/.ssh/OpenWrt_id_rsa.pub\" < ~/.ssh/id_rsa.pub # "
+"Transfer public key to PVE<br/>ssh root@${pve_host} -p ${pve_port} \"cat ~/."
+"ssh/OpenWrt_id_rsa.pub >> ~/.ssh/authorized_keys\" # Write public key to "
+"PVE<br/>ssh -i /root/.ssh/id_rsa root@${pve_host} -p ${pve_port} sensors # "
+"To avoid script errors during the initial connection, please use a private "
+"key to connect to PVE and test the temperature command for its proper "
+"functioning.<br/>For users who frequently flash firmware, please add /root/."
+"ssh/ to the backup list to avoid duplicate operations."
+msgstr ""
+"SSH 端口默认为 22，如有自定义，请填写自定义 SSH 端口<br/>请确认已经设置好密钥"
+"登陆，否则会引起脚本无法运行等错误！<br/>PVE 安装 sensors 命令自行百度<br/>密"
+"钥登陆例（自行修改地址与端口号）：<br/>opkg update #更新列表<br/>opkg "
+"install openssh-client openssh-keygen #安装openssh客户端<br/>echo -e \"\\n\" "
+"| ssh-keygen -t rsa # 生成密钥文件（空密码）<br/>pve_host=`uci get "
+"wechatpush.config.server_host` || pve_host=\"10.0.0.3\" # 读取配置文件中的 "
+"pve 主机地址，如果未保存设置，请自行填写 <br/>pve_port=`uci get wechatpush."
+"config.server_port` || pve_port=\"22\" # 读取配置文件中的 pve 主机 ssh 端口"
+"号，如果未保存设置，请自行填写 <br/>ssh -o StrictHostKeyChecking=yes "
+"root@${pve_host} -p ${pve_port} \"tee -a ~/.ssh/OpenWrt_id_rsa.pub\" < ~/."
+"ssh/id_rsa.pub # 传送公钥到 PVE<br/>ssh root@${pve_host} -p ${pve_port} "
+"\"cat ~/.ssh/OpenWrt_id_rsa.pub >> ~/.ssh/authorized_keys\" # 写入公钥到 "
+"PVE<br/>ssh -i /root/.ssh/id_rsa root@${pve_host} -p ${pve_port} sensors # 因"
+"首次连接时需要确认，为避免脚本错误，请使用私钥连接 PVE 并测试温度命令是否正常"
+"运行。<br/>刷机党自行将 /root/.ssh/ 加入备份列表，避免重复操作"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:76
 msgid "Test temperature command"
@@ -918,8 +1137,17 @@ msgid "Scan local IP"
 msgstr "扫描局域网 IP"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:95
-msgid "When OpenWrt is used as a bypass gateway and cannot obtain device hostnames or a complete list of local network devices.<br/>the \"Retrieve hostname list from modem\" option has only been tested with HG5143F/HN8145V China Telecom gateways and may not be universally applicable.<br/>The \"Scan local IP\" option may not retrieve hostnames, so please use device name annotations in conjunction with it."
-msgstr "适用于 OpenWrt 作为旁路网关，无法获取设备主机名及完整的局域网设备列表时<br/>\"从光猫获取主机名列表\"选项仅测试通过 HG5143F/HN8145V 天翼网关，不保证通用性<br/>\"定期扫描局域网 IP\"选项可能无法获取主机名，请配合设备名备注使用"
+msgid ""
+"When OpenWrt is used as a bypass gateway and cannot obtain device hostnames "
+"or a complete list of local network devices.<br/>the \"Retrieve hostname "
+"list from modem\" option has only been tested with HG5143F/HN8145V China "
+"Telecom gateways and may not be universally applicable.<br/>The \"Scan local "
+"IP\" option may not retrieve hostnames, so please use device name "
+"annotations in conjunction with it."
+msgstr ""
+"适用于 OpenWrt 作为旁路网关，无法获取设备主机名及完整的局域网设备列表时<br/"
+">\"从光猫获取主机名列表\"选项仅测试通过 HG5143F/HN8145V 天翼网关，不保证通用"
+"性<br/>\"定期扫描局域网 IP\"选项可能无法获取主机名，请配合设备名备注使用"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:97
 msgid "Optical modem login URL"
@@ -930,15 +1158,23 @@ msgid "Device list JSON URL"
 msgstr "设备列表 JSON URL"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:105
-msgid "Use F12 console to capture<br/>ip, devName, model are mandatory fields. Example JSON file information:<br/>{\"pc1\":{\"devName\":\"RouterOS\",\"model\":\"\",\"type\":\"pc\",\"ip\":\"192.168.1.7\"}}"
-msgstr "使用 F12 控制台自行抓取<br/>ip、devName、model 为必须项，JSON 文件信息范例：<br/>{\"pc1\":{\"devName\":\"RouterOS\",\"model\":\"\",\"type\":\"pc\",\"ip\":\"192.168.1.7\"}}"
+msgid ""
+"Use F12 console to capture<br/>ip, devName, model are mandatory fields. "
+"Example JSON file information:<br/>{\"pc1\":{\"devName\":\"RouterOS\","
+"\"model\":\"\",\"type\":\"pc\",\"ip\":\"192.168.1.7\"}}"
+msgstr ""
+"使用 F12 控制台自行抓取<br/>ip、devName、model 为必须项，JSON 文件信息范例："
+"<br/>{\"pc1\":{\"devName\":\"RouterOS\",\"model\":\"\",\"type\":\"pc\","
+"\"ip\":\"192.168.1.7\"}}"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:108
 msgid "Optical modem logout URL"
 msgstr "光猫注销登录 URL"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:111
-msgid "Not a mandatory field, but it may affect other users logging into the web management page, e.g., HG5143F"
+msgid ""
+"Not a mandatory field, but it may affect other users logging into the web "
+"management page, e.g., HG5143F"
 msgstr "非必须项，但可能会影响其他用户登录 Web 管理页面，如 HG5143F"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:114
@@ -982,7 +1218,9 @@ msgid "Unattended tasks"
 msgstr "无人值守任务"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:151
-msgid "Please make sure the script can run properly, otherwise it may cause frequent restarts and other errors!"
+msgid ""
+"Please make sure the script can run properly, otherwise it may cause "
+"frequent restarts and other errors!"
 msgstr "请确认脚本可以正常运行，否则可能造成频繁重启等错误！"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:153
@@ -990,7 +1228,9 @@ msgid "Restart zerotier after IP change"
 msgstr "IP 变化后重启 zerotier"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:154
-msgid "An old issue with zerotier<br/>Cannot reconnect after disconnection, emmm, I don't know if it has been fixed now."
+msgid ""
+"An old issue with zerotier<br/>Cannot reconnect after disconnection, emmm, I "
+"don't know if it has been fixed now."
 msgstr "zerotier 的陈年老问题<br/>断网后不能重新打洞，emmm，我也不知道修了没有"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:157
@@ -998,12 +1238,24 @@ msgid "Redial only during Do-Not-Disturb period"
 msgstr "仅在免打扰时段重拨"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:160
-msgid "Avoid redialing network during the day to prevent waiting for DDNS domain resolution. This feature does not affect disconnection detection.<br/>Due to the issue of certain apps consuming excessive data at night, this feature may be unstable."
-msgstr "避免在白天重拨网络造成 DDNS 域名等待解析，此功能不影响断网检测<br/>因夜间某些 APP 偷跑流量问题，该功能可能不稳定"
+msgid ""
+"Avoid redialing network during the day to prevent waiting for DDNS domain "
+"resolution. This feature does not affect disconnection detection.<br/>Due to "
+"the issue of certain apps consuming excessive data at night, this feature "
+"may be unstable."
+msgstr ""
+"避免在白天重拨网络造成 DDNS 域名等待解析，此功能不影响断网检测<br/>因夜间某"
+"些 APP 偷跑流量问题，该功能可能不稳定"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:165
-msgid "Will only be executed when none of the devices in the list are online.<br/>After an hour of Do-Not-Disturb period, if the devices in the focus list have low traffic (around 100kb/m) for five minutes, they will be considered offline."
-msgstr "只会在列表中设备都不在线时才会执行<br/>免打扰时段一小时后，关注设备五分钟低流量（约100kb/m）将视为离线"
+msgid ""
+"Will only be executed when none of the devices in the list are online.<br/"
+">After an hour of Do-Not-Disturb period, if the devices in the focus list "
+"have low traffic (around 100kb/m) for five minutes, they will be considered "
+"offline."
+msgstr ""
+"只会在列表中设备都不在线时才会执行<br/>免打扰时段一小时后，关注设备五分钟低流"
+"量（约100kb/m）将视为离线"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:169
 msgid "When the network is disconnected"
@@ -1025,8 +1277,14 @@ msgid "Redialing network"
 msgstr "重新拨号"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:174
-msgid "The restart operation will occur ten minutes after the network disconnection and will be attempted a maximum of two times. If the option to log in to the optical modem is available, this operation will attempt to restart the optical modem.<br/>【!!This feature cannot guarantee compatibility!!】"
-msgstr "重启操作将在网络断开十分钟后进行，且最多尝试两次。如果光猫登录选项可用，此操作将会尝试重启光猫。<br/>【！！此功能无法保证兼容性！！】"
+msgid ""
+"The restart operation will occur ten minutes after the network disconnection "
+"and will be attempted a maximum of two times. If the option to log in to the "
+"optical modem is available, this operation will attempt to restart the "
+"optical modem.<br/>【!!This feature cannot guarantee compatibility!!】"
+msgstr ""
+"重启操作将在网络断开十分钟后进行，且最多尝试两次。如果光猫登录选项可用，此操"
+"作将会尝试重启光猫。<br/>【！！此功能无法保证兼容性！！】"
 
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/advanced.js:177
 msgid "Scheduled reboot"


### PR DESCRIPTION
下面是具体提示信息
Poedit 自动修复了“wechatpush.po”文件中的无效内容。
该文件中包含重复的项目，这是不允许的，并且影响了该文件被使用。Poedit 修复了该问题，但您应该审阅任何已被标记为“需要处理”的翻译和纠正它们（如有必要）。