### PR TITLE
修复推送信息中客户端名称错误

### DIFF
--- a/root/usr/share/wechatpush/wechatpush
+++ b/root/usr/share/wechatpush/wechatpush
@@ -418,7 +418,7 @@ process_and_check() {
 	[ -z "$1" ] && return 1
 	local value=$(echo "$1" | tr -d '\n\r' | awk '$1=$1' | sed 's/_/ /g' | grep -v "^$" | sort -u | head -n1)
 	[ "$value" == "unknown" ] && value=""
-	[ -n "$value" ] && [ -n "$2" ] && echo $(cut_str "$value" "$2") && return 0
+	[ -n "$value" ] && [ -n "$2" ] && echo "$(cut_str "$value" "$2")" && return 0
 	[ -n "$value" ] && echo "$value" && return 0
 	return 1
 }


### PR DESCRIPTION
修复 https://github.com/tty228/luci-app-wechatpush/issues/345

当 `value` 为 `*` 时，`echo $(cut_str "$value" "$2")` 会输出当前目录下的所有文件和文件夹名称而不是 `*` 本身，需要用引号包围。