### PR TITLE
fix: prevent PermissionError on advanced settings page (#405)

### DIFF
--- a/htdocs/luci-static/resources/view/wechatpush/advanced.js
+++ b/htdocs/luci-static/resources/view/wechatpush/advanced.js
@@ -16,25 +16,34 @@ return view.extend({
 
 	load: function () {
 		return Promise.all([
-			this.callHostHints(),
-			fs.read('/proc/net/arp')
+			this.callHostHints()
 		]);
 	},
 
-	parseArp: function (data) {
-		var lines = data.split('\n'),
-			hosts = [];
+	parseHostHints: function (data) {
+		var hosts = [];
 
-		for (var i = 1; i < lines.length; i++) {
-			var columns = lines[i].replace(/ +/g, ' ').split(' ');
+		Object.keys(data || {}).forEach(function (mac) {
+			var hint = data[mac] || {},
+				ipaddrs = hint.ipaddrs || hint.ipv4 || [];
 
-			if (columns.length >= 6) {
-				hosts.push({
-					ip: columns[0],
-					mac: columns[3]
-				});
-			}
-		}
+			if (!Array.isArray(ipaddrs))
+				ipaddrs = [ ipaddrs ];
+
+			ipaddrs.forEach(function (ip) {
+				var octets = (typeof(ip) === 'string' && /^\d{1,3}(\.\d{1,3}){3}$/.test(ip))
+					? ip.split('.').map(Number) : [];
+
+				if (octets.length === 4 && octets.every(function (octet) {
+					return octet >= 0 && octet <= 255;
+				})) {
+					hosts.push({
+						ip: ip,
+						mac: mac
+					});
+				}
+			});
+		});
 
 		// Sort hosts array by IP address
 		hosts.sort(function (a, b) {
@@ -62,8 +71,7 @@ return view.extend({
 	},
 
 	render: function (data) {
-		var arpData = data[1],
-			hosts = this.parseArp(arpData),
+		var hosts = this.parseHostHints(data[0]),
 			m, s, o,
 			programPath = '/usr/share/wechatpush/wechatpush';
 

--- a/root/usr/share/rpcd/acl.d/luci-app-wechatpush.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-wechatpush.json
@@ -4,13 +4,13 @@
 		"read": {
 			"file": {
 				"/etc/init.d/wechatpush": [ "exec" ],
-				"/proc/net/arp": [ "read" ],
 				"/usr/share/wechatpush/wechatpush": [ "exec" ],
 				"/tmp/wechatpush/*": [ "read" ],
 				"/usr/share/wechatpush/api/*": [ "read" ],
 				"/usr/libexec/wechatpush-call": [ "exec" ]
 			},
 			"ubus": {
+				"luci-rpc": [ "getHostHints" ],
 				"service": [ "list" ]
 			},
 			"uci": [ "wechatpush" ]


### PR DESCRIPTION
修复 #405。

新版 rpcd 会先解析 `/proc/net` 的符号链接，再按照真实路径检查 ACL。原先直接读取 `/proc/net/arp` 的方式因此被拒绝，导致高级设置页面加载失败。

本次改为使用 LuCI 的 `luci-rpc.getHostHints` 获取主机信息，同时兼容旧版的 `ipv4` 和新版的 `ipaddrs` 返回格式，并移除不再需要的 `/proc/net/arp` 文件权限。

已在 OpenWrt SNAPSHOT 上测试通过。