### PR TITLE
feat: add WPUSH API push channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | :-------- | :----- | :----- |
 | 微信 | Server酱 | https://sct.ftqq.com/
 | 微信 | 推送加 | http://www.pushplus.plus/
+| 微信等 | WPUSH | https://wpush.cn/
 | 微信 | WxPusher | https://wxpusher.zjiecode.com/docs
 | 企业微信 | 应用推送 | https://work.weixin.qq.com/api/doc/90000/90135/90248
 | Telegram | bot | https://t.me/BotFather

--- a/README_en.md
+++ b/README_en.md
@@ -22,6 +22,7 @@ Supported services:
 | :-------- | :----- | :----- |
 | WeChat | Server Chan | https://sct.ftqq.com/
 | WeChat | PushPlus | http://www.pushplus.plus/
+| WeChat etc. | WPUSH | https://wpush.cn/
 | WeChat | WxPusher | https://wxpusher.zjiecode.com/docs
 | WeChat for Enterprise | Application Push | https://work.weixin.qq.com/api/doc/90000/90135/90248
 | Telegram | bot | https://t.me/BotFather

--- a/htdocs/luci-static/resources/view/wechatpush/config.js
+++ b/htdocs/luci-static/resources/view/wechatpush/config.js
@@ -146,6 +146,8 @@ return view.extend({
 			_('Another channel for WeChat push, the configuration is relatively simple, and only supports official accounts'));
 		o.value('/usr/share/wechatpush/api/pushplus.json', _('pushplus'),
 			_('Another channel for WeChat push, the configuration is relatively simple, and it supports multiple push methods'));
+		o.value('/usr/share/wechatpush/api/wpush.json', _('WPUSH'),
+			_('Multi-channel push via WPUSH (WeChat, App, Feishu, DingTalk, and more). Success when response code===0'));
 		o.value('/usr/share/wechatpush/api/telegram.json', _('Telegram'),
 			_('Telegram Bot Push'));
 		o.value('/usr/share/wechatpush/api/msmtp.json', _('msmtp'),
@@ -221,6 +223,11 @@ return view.extend({
 		o.description = _('Get Instructions') + ' <a href="http://www.pushplus.plus/" target="_blank">' + _('Click here') + '</a>';
 		o.rmempty = false;
 		o.depends('jsonpath', '/usr/share/wechatpush/api/pushplus.json');
+
+		o = s.taboption('basic', form.Value, 'wpush_apikey', _('WPUSH apikey'));
+		o.description = _('Get Instructions') + ' <a href="https://wpush.cn/" target="_blank">' + _('Click here') + '</a>' + _('<br />API docs: https://docs.wpush.cn/docs/api/message.html — success when code===0');
+		o.rmempty = false;
+		o.depends('jsonpath', '/usr/share/wechatpush/api/wpush.json');
 
 		o = s.taboption('basic', form.Value, 'tg_token', _('Bot Token'));
 		o.description = _('Get Bot') + ' <a href="https://t.me/BotFather" target="_blank">' + _('Click here') + '</a>' + _('<br />Send a message to the created bot to initiate a conversation.');
@@ -311,6 +318,7 @@ return view.extend({
 		o.depends('jsonpath', '/usr/share/wechatpush/api/qywx_mpnews.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/wxpusher.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/pushplus.json');
+		o.depends('jsonpath', '/usr/share/wechatpush/api/wpush.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/telegram.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/diy.json');
 
@@ -336,6 +344,7 @@ return view.extend({
 		o.depends('jsonpath', '/usr/share/wechatpush/api/qywx_mpnews.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/wxpusher.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/pushplus.json');
+		o.depends('jsonpath', '/usr/share/wechatpush/api/wpush.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/telegram.json');
 		o.depends('jsonpath', '/usr/share/wechatpush/api/diy.json');
 

--- a/po/zh_Hans/wechatpush.po
+++ b/po/zh_Hans/wechatpush.po
@@ -100,6 +100,22 @@ msgstr "微信推送的另一个通道，配置较简单，只支持公众号"
 msgid "Another channel for WeChat push, the configuration is relatively simple, and it supports multiple push methods"
 msgstr "微信推送的另一个通道，配置较简单，支持多项推送方式"
 
+#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
+msgid "WPUSH"
+msgstr "WPUSH"
+
+#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
+msgid "Multi-channel push via WPUSH (WeChat, App, Feishu, DingTalk, and more). Success when response code===0"
+msgstr "通过 WPUSH 多通道推送（微信、App、飞书、钉钉等）。成功判定为响应 code===0"
+
+#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
+msgid "WPUSH apikey"
+msgstr "WPUSH apikey"
+
+#: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js
+msgid "<br />API docs: https://docs.wpush.cn/docs/api/message.html — success when code===0"
+msgstr "<br />接口文档：https://docs.wpush.cn/docs/api/message.html — 成功时 code===0"
+
 #: applications/luci-app-wechatpush/htdocs/luci-static/resources/view/wechatpush/config.js:146
 msgid "Telegram Bot Push"
 msgstr "Telegram bot 推送，若无梯子，请勿使用"

--- a/root/usr/share/wechatpush/api/wpush.json
+++ b/root/usr/share/wechatpush/api/wpush.json
@@ -1,0 +1,21 @@
+{
+	"_api": "这是 wpush api 文件",
+	"_api": "【wpush】",
+	"_readme": "成功判定：响应 JSON 的 application code===0（pushplus 为 code===200；本插件与 pushplus 相同，diy_send 仅检查 curl 退出码）",
+	
+	"url": "https://api.wpush.cn/api/v1/send",
+	"data": "@${tempjsonpath}",
+	"content_type": "Content-Type: application/json",
+	"str_title_start": "##### ",
+	"str_title_end": "",
+	"str_linefeed": "\\n",
+	"str_splitline": "\\n----\\n",
+	"str_space": " ",
+	"str_tab": "    ",
+	"type":
+	{
+		"title": "\"${1}\"",
+		"content": "\"${2}\"",
+		"apikey": "\"${wpush_apikey}\""
+	}
+}

--- a/root/usr/share/wechatpush/wechatpush
+++ b/root/usr/share/wechatpush/wechatpush
@@ -44,7 +44,7 @@ wait_and_cat() {
 read_config() {
 	get_config \
 		"enable" "lite_enable" "device_name" "proxy_address" "sleeptime" "oui_data" "reset_regularly" "debuglevel" "lang" \
-		"jsonpath" "sckey" "sc3key" "sc3uid" "sc3tags" "corpid" "userid" "agentid" "corpsecret" "mediapath" "wxpusher_apptoken" "wxpusher_uids" "wxpusher_topicIds" "pushplus_token" "tg_api_server" "tg_token" "tg_chat_id" "tg_thread_id" "recipient_email" "smtp_host" "smtp_port" "smtp_tls" "smtp_starttls" "smtp_user" "smtp_passwordeval" "smtp_from" "smtp_from_full_name" \
+		"jsonpath" "sckey" "sc3key" "sc3uid" "sc3tags" "corpid" "userid" "agentid" "corpsecret" "mediapath" "wxpusher_apptoken" "wxpusher_uids" "wxpusher_topicIds" "pushplus_token" "wpush_apikey" "tg_api_server" "tg_token" "tg_chat_id" "tg_thread_id" "recipient_email" "smtp_host" "smtp_port" "smtp_tls" "smtp_starttls" "smtp_user" "smtp_passwordeval" "smtp_from" "smtp_from_full_name" \
 		"get_ipv4_mode" "ipv4_interface" "get_ipv6_mode" "ipv6_interface" \
 		"device_notification" "cpu_notification" "cpu_load_threshold" "temperature_threshold" \
 		"client_usage" "client_usage_max" "client_usage_disturb" "client_usage_whitelist" \
@@ -174,7 +174,7 @@ init() {
 	[ -z "$ip_version" ] && log_change "[ERROR] $(translate "Cannot get iputils-arping version, please confirm if plugin is running properly")"
 	[ -z "$cu_version" ] && log_change "[ERROR] $(translate "Cannot get curl version, please confirm if plugin is running properly")"
 
-	[ -n "$jsonpath" ] && [ -z "${sckey}${sc3key}${sc3uid}${sc3tags}${tg_token}${pushplus_token}${corpid}${wxpusher_apptoken}${wxpusher_uids}${wxpusher_topicIds}${recipient_email}" -a "${jsonpath}" != "/usr/share/wechatpush/api/diy.json" ] && log_change "[ERROR] $(translate "Please fill in the correct API key")" && return 1
+	[ -n "$jsonpath" ] && [ -z "${sckey}${sc3key}${sc3uid}${sc3tags}${tg_token}${pushplus_token}${wpush_apikey}${corpid}${wxpusher_apptoken}${wxpusher_uids}${wxpusher_topicIds}${recipient_email}" -a "${jsonpath}" != "/usr/share/wechatpush/api/diy.json" ] && log_change "[ERROR] $(translate "Please fill in the correct API key")" && return 1
 
 	local interfacelist=$(getinterfacelist) && [ -z "$interfacelist" ] && log_change "[WARN] $(translate "Multiple interfaces detected or configuration error, may not get interface uptime information, please confirm if plugin is running properly")"
 


### PR DESCRIPTION
## Summary

Add **WPUSH** as a built-in push channel, mirroring the existing `pushplus.json` template pattern.

- New API template: `root/usr/share/wechatpush/api/wpush.json`
  - Endpoint: `https://api.wpush.cn/api/v1/send`
  - JSON body: `title` / `content` / `apikey` (from LuCI `wpush_apikey`)
  - Markdown formatting tokens aligned with pushplus
  - Documented that WPUSH application success is `code===0` (pushplus uses `200`); `diy_send` still only checks curl exit status, same as existing channels
- LuCI: push mode option, apikey field, proxy + send-test `depends`
- Shell: load `wpush_apikey` and include it in the “API key filled” check
- README / README_en channel tables + `zh_Hans` strings

## Test plan

- [ ] Select **WPUSH** push mode, fill apikey from https://wpush.cn/, save
- [ ] Click **Send Test**; message arrives; log shows `【wpush】`
- [ ] Confirm proxy option appears for WPUSH like pushplus
- [ ] Other channels (serverchan / pushplus / telegram) unchanged